### PR TITLE
Concurrent hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "pbs": "^1.3.2"
   },
   "devDependencies": {
+    "async": "^1.2.1",
     "concat-stream": "^1.4.8",
     "memdown": "^1.0.0",
     "standard": "^3.7.0",
+    "subleveldown": "^2.0.0",
     "tape": "^4.0.0"
   },
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -54,7 +54,7 @@ var pbs = function (down, encode, decode) {
     var end = function () {
       ended = true
       iterators[req.id] = null
-      while (iterators.length && iterators[iterators.length - 1]) iterators.pop()
+      while (iterators.length && !iterators[iterators.length - 1]) iterators.pop()
       iterator.end(noop)
     }
 

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -6,7 +6,8 @@ var sublevel = require('subleveldown')
 var async = require('async')
 
 tape('concurrent read-stream of size 1', function (t) {
-  t.timeoutAfter(30000)
+  t.plan(2)
+  t.timeoutAfter(50000)
   var db = levelup('whatever', { db: memdown })
   var stream = multileveldown.server(db)
   var client = multileveldown.client()
@@ -25,7 +26,6 @@ tape('concurrent read-stream of size 1', function (t) {
     t.error(err, 'no err')
     stripe(ids, function (err) {
       t.error(err, 'no error striping')
-      t.end()
     })
   })
 
@@ -33,11 +33,9 @@ tape('concurrent read-stream of size 1', function (t) {
     if (!ids.length) { return callback() }
 
     var newIds = []
-    async.eachLimit(ids, 2, function (k, next) {
+    async.each(ids, function (k, next) {
       var sub = dbs[k]
-      console.log('before read')
       peek(sub, function (err, data) {
-        console.log('after read')
         if (err) { return next(err) }
 
         if (!data) {
@@ -45,10 +43,8 @@ tape('concurrent read-stream of size 1', function (t) {
         }
 
         newIds.push(k)
-        console.log('before delete')
         resilDelete(sub, data.key, function (err) {
           if (err) { return next(err) }
-          console.log('after delete')
           next()
         })
       })

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -1,0 +1,99 @@
+var tape = require('tape')
+var memdown = require('memdown')
+var multileveldown = require('..')
+var levelup = require('levelup')
+var sublevel = require('subleveldown')
+var async = require('async')
+
+tape('concurrent read-stream of size 1', function (t) {
+  t.timeoutAfter(30000)
+  var db = levelup('whatever', { db: memdown })
+  var stream = multileveldown.server(db)
+  var client = multileveldown.client()
+  stream.pipe(client.connect()).pipe(stream)
+
+  var dbs = {}
+  var ids = Array.apply(null, new Array(100))
+    .map(function () { return process.hrtime().join('-') })
+
+  async.each(ids, function (id, next) {
+    var sub = dbs[id] = sublevel(client, id, { valueEncoding: 'json' })
+
+    sub.batch(generateBatch(500), next)
+
+  }, function (err) {
+    t.error(err, 'no err')
+    stripe(ids, function (err) {
+      t.error(err, 'no error striping')
+      t.end()
+    })
+  })
+
+  function stripe (ids, callback) {
+    if (!ids.length) { return callback() }
+
+    var newIds = []
+    async.eachLimit(ids, 2, function (k, next) {
+      var sub = dbs[k]
+      console.log('before read')
+      peek(sub, function (err, data) {
+        console.log('after read')
+        if (err) { return next(err) }
+
+        if (!data) {
+          return next()
+        }
+
+        newIds.push(k)
+        console.log('before delete')
+        resilDelete(sub, data.key, function (err) {
+          if (err) { return next(err) }
+          console.log('after delete')
+          next()
+        })
+      })
+    }, function (err) {
+      if (err) { return callback(err) }
+
+      stripe(newIds, callback)
+    })
+
+  }
+
+})
+
+function resilDelete (db, key, cb) {
+  db.batch([{ type: 'del', key: key }], function (err) {
+    if (err) {
+      console.error('Error deleting key %s', key)
+      if (!err.notFound) {
+        return void setImmediate(resilDelete, db, key, cb)
+      }
+    }
+
+    cb()
+  })
+}
+
+function generateBatch (len) {
+  return Array.apply(null, new Array(len)).map(function (i) {
+    return {
+      type: 'put',
+      key: process.hrtime().join('-'),
+      value: { what: 'fuck' }
+    }
+  })
+}
+
+function peek (d, cb) {
+  var data
+  var called = false
+  d.createReadStream({ limit: 1 }).on('data', function (d) {
+    data = d
+  }).on('error', function (err) {
+    called = true
+    cb(err)
+  }).on('end', function () {
+    if (!called) cb(null, data)
+  })
+}


### PR DESCRIPTION
Adds a failing test showing how the database hangs when concurrent `readStream({ limit: 1 })` occur.