### PR TITLE
fixed non working reconnect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ var db = multileveldown.client({
 
 var connect = function () {
   var sock = net.connect(9000)
+  var remote = db.connect()
 
   sock.on('error', function () {
     sock.destroy()
   })
 
   sock.on('close', function () {
+    remote.destroy()
     setTimeout(connect, 1000) // reconnect after 1s
   })
 
-  sock.pipe(db.connect()).pipe(sock)
+  sock.pipe(remote).pipe(sock)
 }
 
 connect()


### PR DESCRIPTION
reconnect example failed at https://github.com/mafintosh/multileveldown/blob/master/leveldown.js#L42

Fixed `reconnect example` adding an extra `destroy`

I also tested that pending db operations are executed when the connection resumes.